### PR TITLE
add label alignment settings for canvas

### DIFF
--- a/src/renderers/canvas/sigma.canvas.hovers.def.js
+++ b/src/renderers/canvas/sigma.canvas.hovers.def.js
@@ -37,7 +37,7 @@
       (node.color || settings('defaultNodeColor')) :
       settings('defaultHoverLabelBGColor');
 
-    if (node.label && settings('labelHoverShadow')) {
+    if (settings('labelHoverShadow')) {
       context.shadowOffsetX = 0;
       context.shadowOffsetY = 0;
       context.shadowBlur = 8;
@@ -50,81 +50,7 @@
       alignment = settings('labelAlignment');
     }
 
-    if (node.label && typeof node.label === 'string') {
-      x = Math.round(node[prefix + 'x']);
-      y = Math.round(node[prefix + 'y']);
-      w = Math.round(
-        context.measureText(node.label).width + size + 1.5 + fontSize / 3
-      );
-      h = Math.round(fontSize + 4);
-      e = size + fontSize / 3;
-
-      // draw a circle for the node first
-      context.moveTo(x, y - e);
-      context.arcTo(x + e, y - e, x + e, y, e);
-      context.arcTo(x + e, y + e, x, y + e, e);
-      context.arcTo(x - e, y + e, x - e, y, e);
-      context.arcTo(x - e, y - e, x, y - e, e);
-
-      // then a rectangle for the label
-      switch (alignment) {
-        case 'center':
-          break;
-        case 'left':
-          y = Math.round(node[prefix + 'y'] - fontSize / 2 - 2);
-          context.moveTo(x, y);
-          context.lineTo(x, y + h);
-          context.lineTo(x - w, y + h);
-          context.lineTo(x - w, y);
-          context.lineTo(x, y);
-          break;
-        case 'top':
-          y = Math.round(node[prefix + 'y'] - e);
-
-          context.moveTo(x, y);
-          context.lineTo(x + w / 2 , y);
-          context.lineTo(x + w / 2, y - h);
-          context.lineTo(x - w / 2, y - h);
-          context.lineTo(x - w / 2, y);
-          context.lineTo(x, y);
-          break;
-        case 'bottom':
-          y = Math.round(node[prefix + 'y'] + e);
-
-          context.moveTo(x, y);
-          context.lineTo(x + w / 2 , y);
-          context.lineTo(x + w / 2, y + h);
-          context.lineTo(x - w / 2, y + h);
-          context.lineTo(x - w / 2, y);
-          context.lineTo(x, y);
-          break;
-        case 'inside':
-          if (context.measureText(node.label).width <= e * 2) {
-            // don't draw anything
-            break;
-          }
-          // use default setting, falling through
-        /* falls through*/
-        case 'right':
-        /* falls through*/
-        default:
-          y = Math.round(node[prefix + 'y'] - fontSize / 2 - 2);
-
-          context.moveTo(x, y);
-          context.lineTo(x + w, y);
-          context.lineTo(x + w, y + h);
-          context.lineTo(x, y + h);
-          context.lineTo(x, y);
-          break;
-      }
-
-      context.closePath();
-      context.fill();
-
-      context.shadowOffsetX = 0;
-      context.shadowOffsetY = 0;
-      context.shadowBlur = 0;
-    }
+    drawHoverBorder(alignment, context, fontSize, node);
 
     // Node border:
     if (settings('borderSize') > 0) {
@@ -148,8 +74,14 @@
     var nodeRenderer = sigma.canvas.nodes[node.type] || sigma.canvas.nodes.def;
     nodeRenderer(node, context, settings);
 
-    // Display the label:
-    if (typeof node.label === 'string') {
+    displayLabel(alignment, context, fontSize, node);
+
+    function displayLabel(alignment, context, fontSize, node) {
+      if (node.label === null || node.label === undefined ||
+          typeof node.label !== 'string') {
+        return;
+      }
+
       context.fillStyle = (settings('labelHoverColor') === 'node') ?
         (node.color || settings('defaultNodeColor')) :
         settings('defaultLabelHoverColor');
@@ -189,6 +121,84 @@
         Math.round(node[prefix + 'x'] + xOffset),
         Math.round(node[prefix + 'y'] + yOffset)
       );
+    }
+
+    function drawHoverBorder(alignment, context, fontSize, node) {
+      x = Math.round(node[prefix + 'x']);
+      y = Math.round(node[prefix + 'y']);
+      w = Math.round(
+        context.measureText(node.label).width + size + 1.5 + fontSize / 3
+      );
+      h = Math.round(fontSize + 4);
+      e = size + fontSize / 3;
+
+      // draw a circle for the node first
+      context.moveTo(x, y - e);
+      context.arcTo(x + e, y - e, x + e, y, e);
+      context.arcTo(x + e, y + e, x, y + e, e);
+      context.arcTo(x - e, y + e, x - e, y, e);
+      context.arcTo(x - e, y - e, x, y - e, e);
+
+      if (node.label && typeof node.label === 'string') {
+        // then a rectangle for the label
+        switch (alignment) {
+          case 'center':
+            break;
+          case 'left':
+            y = Math.round(node[prefix + 'y'] - fontSize / 2 - 2);
+            context.moveTo(x, y);
+            context.lineTo(x, y + h);
+            context.lineTo(x - w, y + h);
+            context.lineTo(x - w, y);
+            context.lineTo(x, y);
+            break;
+          case 'top':
+            y = Math.round(node[prefix + 'y'] - e);
+
+            context.moveTo(x, y);
+            context.lineTo(x + w / 2 , y);
+            context.lineTo(x + w / 2, y - h);
+            context.lineTo(x - w / 2, y - h);
+            context.lineTo(x - w / 2, y);
+            context.lineTo(x, y);
+            break;
+          case 'bottom':
+            y = Math.round(node[prefix + 'y'] + e);
+
+            context.moveTo(x, y);
+            context.lineTo(x + w / 2 , y);
+            context.lineTo(x + w / 2, y + h);
+            context.lineTo(x - w / 2, y + h);
+            context.lineTo(x - w / 2, y);
+            context.lineTo(x, y);
+            break;
+          case 'inside':
+            if (context.measureText(node.label).width <= e * 2) {
+              // don't draw anything
+              break;
+            }
+            // use default setting, falling through
+          /* falls through*/
+          case 'right':
+          /* falls through*/
+          default:
+            y = Math.round(node[prefix + 'y'] - fontSize / 2 - 2);
+
+            context.moveTo(x, y);
+            context.lineTo(x + w, y);
+            context.lineTo(x + w, y + h);
+            context.lineTo(x, y + h);
+            context.lineTo(x, y);
+            break;
+        }
+      }
+
+      context.closePath();
+      context.fill();
+
+      context.shadowOffsetX = 0;
+      context.shadowOffsetY = 0;
+      context.shadowBlur = 0;
     }
   };
 }).call(this);

--- a/src/renderers/canvas/sigma.canvas.labels.def.js
+++ b/src/renderers/canvas/sigma.canvas.labels.def.js
@@ -17,13 +17,23 @@
   sigma.canvas.labels.def = function(node, context, settings) {
     var fontSize,
         prefix = settings('prefix') || '',
-        size = node[prefix + 'size'];
+        size = node[prefix + 'size'],
+        labelWidth = 0,
+        labelPlacementX,
+        labelPlacementY,
+        alignment;
 
     if (size < settings('labelThreshold'))
       return;
 
     if (typeof node.label !== 'string')
       return;
+
+    if (settings('labelAlignment') === undefined) {
+      alignment = settings('defaultLabelAlignment');
+    } else {
+      alignment = settings('labelAlignment');
+    }
 
     fontSize = (settings('labelSize') === 'fixed') ?
       settings('defaultLabelSize') :
@@ -35,10 +45,45 @@
       (node.color || settings('defaultNodeColor')) :
       settings('defaultLabelColor');
 
+    labelWidth = context.measureText(node.label).width;
+    labelPlacementX = Math.round(node[prefix + 'x'] + size + 3);
+    labelPlacementY = Math.round(node[prefix + 'y'] + fontSize / 3);
+
+    switch (alignment) {
+      case 'inside':
+        if (labelWidth >= (size + fontSize / 3) * 2) {
+          labelPlacementX = Math.round(node[prefix + 'x'] + size + 3);
+          break;
+        }
+      /* falls through*/
+      case 'center':
+        labelPlacementX = Math.round(node[prefix + 'x'] - labelWidth / 2);
+        break;
+      case 'left':
+        labelPlacementX =
+            Math.round(node[prefix + 'x'] - size - labelWidth - 3);
+        break;
+      case 'right':
+        labelPlacementX = Math.round(node[prefix + 'x'] + size + 3);
+        break;
+      case 'top':
+        labelPlacementX = Math.round(node[prefix + 'x'] - labelWidth / 2);
+        labelPlacementY = labelPlacementY - size - fontSize;
+        break;
+      case 'bottom':
+        labelPlacementX = Math.round(node[prefix + 'x'] - labelWidth / 2);
+        labelPlacementY = labelPlacementY + size + fontSize;
+        break;
+      default:
+        // Default is aligned 'right'
+        labelPlacementX = Math.round(node[prefix + 'x'] + size + 3);
+        break;
+    }
+
     context.fillText(
       node.label,
-      Math.round(node[prefix + 'x'] + size + 3),
-      Math.round(node[prefix + 'y'] + fontSize / 3)
+      labelPlacementX,
+      labelPlacementY
     );
   };
 }).call(this);

--- a/src/sigma.settings.js
+++ b/src/sigma.settings.js
@@ -40,6 +40,8 @@
     defaultNodeColor: '#000',
     // {string}
     defaultLabelSize: 14,
+    // {string}
+    defaultLabelAlignment: 'right',
     // {string} Indicates how to choose the edges color. Available values:
     //          "source", "target", "default"
     edgeColor: 'source',


### PR DESCRIPTION
add label alignment settings for canvs
- add label alignment settings
- fix jslint errors
- when zoom in/out, adjust hovered circle for the node accordingly
- when use "center" setting, the rectangle area will not be displayed
- when use "inside" setting, default setting will be used if the width
  of the label is larger than the hovered circle.