### PR TITLE
SVG: need to hide the edge label elements before performing update

### DIFF
--- a/plugins/sigma.renderers.edgeLabels/sigma.svg.edges.labels.def.js
+++ b/plugins/sigma.renderers.edgeLabels/sigma.svg.edges.labels.def.js
@@ -58,7 +58,7 @@
           size = edge[prefix + 'size'] || 1;
       // Case when we don't want to display the label
       if (!settings('forceLabels') && size < settings('edgeLabelThreshold') ||
-          source === target || edge.hidden) {
+          source === target) {
         text.style.display = 'none';
         return;
       }

--- a/src/renderers/sigma.renderers.svg.js
+++ b/src/renderers/sigma.renderers.svg.js
@@ -156,6 +156,7 @@
     // TODO: find a more sensible way to perform this operation
     this.hideDOMElements(this.domElements.nodes);
     this.hideDOMElements(this.domElements.edges);
+    this.hideDOMElements(this.domElements.edgeLabels);
     this.hideDOMElements(this.domElements.labels);
 
     // Find which nodes are on screen


### PR DESCRIPTION
- hidden is not used by svg the same way canvas uses
- hiding DOMElement before checking if elements are in the camera is
  very inefficient, we should improve the logic