### PR TITLE
Can't drag newly selected node

### DIFF
--- a/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
+++ b/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
@@ -214,7 +214,6 @@
       });
       
       _drag = false;
-      _node = null;
     };
 
     function nodeMouseMove(event) {


### PR DESCRIPTION
Reset _node only when the mouse is outside of the node. Don't reset it for mouseup event