### PR TITLE
prevent default action for mouse down event in the drag plugin

### DIFF
--- a/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
+++ b/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
@@ -177,6 +177,8 @@
           captor: event,
           renderer: _renderer
         });
+
+        event.preventDefault();
       }
     };
 


### PR DESCRIPTION
- chrome changes to text cursor while dragging
- moving cursor outside of the widget window will highlight other
  widgets while dragging