### PR TITLE
SVG image logic to update when image settings are changed

### DIFF
--- a/plugins/sigma.renderers.customShapes/sigma.renderers.customShapes.js
+++ b/plugins/sigma.renderers.customShapes/sigma.renderers.customShapes.js
@@ -93,17 +93,18 @@
         node.image.url);
       group.appendChild(def);
       group.appendChild(image);
-    } else if ((!node.image || !node.image.url) && group.childNodes.length >= 1) {
+    } else if (!node.image || !node.image.url) {
       var childNodes = group.childNodes,
           className,
           i = 0;
       while(i < childNodes.length) {
         className = childNodes[i].getAttribute('class');
-        if (className !== (settings('classPrefix') + '-node')) {
+        // keep node element and remove everything else
+        if (className === (settings('classPrefix') + '-node')) {
+          i++;
+        } else {
           group.removeChild(childNodes[i]);
-          continue;
         }
-        i++;
       }
     }
   }
@@ -194,6 +195,8 @@
                 r*xratio*2*Math.sin(-3.142/4)*(-1));
               childNodes[i].setAttributeNS(null, 'height',
                 r*yratio*2*Math.cos(-3.142/4));
+              // image.url update doesn't make sigma recreate the image
+              // so href needs to be updated here
               childNodes[i].setAttributeNS('http://www.w3.org/1999/xlink', 'href',
                 node.image.url);
               break;

--- a/plugins/sigma.renderers.customShapes/sigma.renderers.customShapes.js
+++ b/plugins/sigma.renderers.customShapes/sigma.renderers.customShapes.js
@@ -67,8 +67,7 @@
     if(node.image && node.image.url && group.childNodes.length === 1) {
       var clipCircle = document.createElementNS(settings('xmlns'), 'circle'),
         clipPath = document.createElementNS(settings('xmlns'), 'clipPath'),
-        clipPathId = settings('classPrefix') + '-clip-path-' +
-          Math.random().toString(36).substring(2, 15),
+        clipPathId = settings('classPrefix') + '-clip-path-' + node.id,
         def = document.createElementNS(settings('xmlns'), 'defs'),
         image = document.createElementNS(settings('xmlns'), 'image'),
         url = node.image.url;
@@ -202,8 +201,8 @@
               // no class name, must be the clip-path
               var clipPath = childNodes[i].firstChild;
               if (clipPath != null) {
-                var clipPathId = clipPath.getAttribute('id');
-                if (clipPathId.indexOf(classPrefix + '-clip-path-') >=0) {
+                var clipPathId = classPrefix + '-clip-path-' + node.id;
+                if (clipPath.getAttribute('id') === clipPathId) {
                   clipPath.firstChild.setAttributeNS(null, 'cx', x);
                   clipPath.firstChild.setAttributeNS(null, 'cy', y);
                   clipPath.firstChild.setAttributeNS(null, 'r',

--- a/plugins/sigma.renderers.customShapes/sigma.renderers.customShapes.js
+++ b/plugins/sigma.renderers.customShapes/sigma.renderers.customShapes.js
@@ -195,6 +195,8 @@
                 r*xratio*2*Math.sin(-3.142/4)*(-1));
               childNodes[i].setAttributeNS(null, 'height',
                 r*yratio*2*Math.cos(-3.142/4));
+              childNodes[i].setAttributeNS('http://www.w3.org/1999/xlink', 'href',
+                node.image.url);
               break;
             default:
               // no class name, must be the clip-path

--- a/plugins/sigma.renderers.customShapes/sigma.renderers.customShapes.js
+++ b/plugins/sigma.renderers.customShapes/sigma.renderers.customShapes.js
@@ -63,11 +63,12 @@
     }
   }
 
-  var drawSVGImage = function (node, group, settings) {
-    if(sigInst && node.image && node.image.url) {
+  var updateSVGImage = function (node, group, settings) {
+    if(node.image && node.image.url && group.childNodes.length === 1) {
       var clipCircle = document.createElementNS(settings('xmlns'), 'circle'),
         clipPath = document.createElementNS(settings('xmlns'), 'clipPath'),
-        clipPathId = settings('classPrefix') + '-clip-path-' + node.id,
+        clipPathId = settings('classPrefix') + '-clip-path-' +
+          Math.random().toString(36).substring(2, 15),
         def = document.createElementNS(settings('xmlns'), 'defs'),
         image = document.createElementNS(settings('xmlns'), 'image'),
         url = node.image.url;
@@ -93,6 +94,18 @@
         node.image.url);
       group.appendChild(def);
       group.appendChild(image);
+    } else if ((!node.image || !node.image.url) && group.childNodes.length >= 1) {
+      var childNodes = group.childNodes,
+          className,
+          i = 0;
+      while(i < childNodes.length) {
+        className = childNodes[i].getAttribute('class');
+        if (className !== (settings('classPrefix') + '-node')) {
+          group.removeChild(childNodes[i]);
+          continue;
+        }
+        i++;
+      }
     }
   }
 
@@ -137,10 +150,10 @@
           node.color || settings('defaultNodeColor'));
 
         group.appendChild(circle);
-        drawSVGImage(node, group, settings);
         return group;
       },
       update: function(node, group, settings) {
+        updateSVGImage(node, group, settings);
         var classPrefix = settings('classPrefix'),
           clip = node.image.clip || 1,
           // 1 is arbitrary, anyway only the ratio counts
@@ -187,8 +200,8 @@
               // no class name, must be the clip-path
               var clipPath = childNodes[i].firstChild;
               if (clipPath != null) {
-                var clipPathId = classPrefix + '-clip-path-' + node.id;
-                if (clipPath.getAttribute('id') === clipPathId) {
+                var clipPathId = clipPath.getAttribute('id');
+                if (clipPathId.indexOf(classPrefix + '-clip-path-') >=0) {
                   clipPath.firstChild.setAttributeNS(null, 'cx', x);
                   clipPath.firstChild.setAttributeNS(null, 'cy', y);
                   clipPath.firstChild.setAttributeNS(null, 'r',


### PR DESCRIPTION
Currently, it draws the image when a new renderer gets instantiated. If
we decide to remove the image property from a node, the nodes won't
reflect the change until they are recreated.