### PR TITLE
use preventDefault for all graph mousedown event

### DIFF
--- a/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
+++ b/plugins/sigma.plugins.dragNodes/sigma.plugins.dragNodes.js
@@ -177,8 +177,6 @@
           captor: event,
           renderer: _renderer
         });
-
-        event.preventDefault();
       }
     };
 

--- a/src/captors/sigma.captors.mouse.js
+++ b/src/captors/sigma.captors.mouse.js
@@ -260,6 +260,7 @@
               shiftKey: e.shiftKey
             });
         }
+        e.preventDefault();
       }
     }
 


### PR DESCRIPTION
This is prevent drag select that highlights the graph container for
chrome